### PR TITLE
Avoid env var naming conflicts and explicitly add env vars to tox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ AWS stack to update another Lambda's environment settings with new Cumulus Distr
 $ export STACKNAME=<Name of your stack>
 $ export PROJECT=<The project name for resource cost tracking>
 $ export LAMBDA=<The Arn of the Lambda that will receive new S3 Credentials>
-$ export USERNAME=<A valid Earth Data Login user name>
-$ export PASSWORD=<A valid Earth Data Login password>
+$ export EDL_USERNAME=<A valid Earth Data Login user name>
+$ export EDL_PASSWORD=<A valid Earth Data Login password>
 ```
 
 ## CDK Commands

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -10,8 +10,8 @@ from aws_cdk import core
 STACKNAME = os.environ["STACKNAME"]
 PROJECT = os.environ["PROJECT"]
 LAMBDA = os.environ["LAMBDA"]
-USERNAME = os.environ["USERNAME"]
-PASSWORD = os.environ["PASSWORD"]
+USERNAME = os.environ["EDL_USERNAME"]
+PASSWORD = os.environ["EDL_PASSWORD"]
 
 
 class Stack(core.Stack):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,10 @@ extras = dev
 passenv =
   STACKNAME
   AWS_*
+  PROJECT
+  LAMBDA
+  EDL_USERNAME
+  EDL_PASSWORD
 commands =
   nodeenv --node=16.3.0 -p
   npm install -g aws-cdk@1.139.0


### PR DESCRIPTION
## What/Why
- Add prefix to environment variables to avoid conflicts with local username/password already in environment. 
- Explicitly configure environment variables in tox.ini.

## How tested
Deployed to AWS for an existing titiler lambda and confirmed that valid session information is added to target lambda environment.